### PR TITLE
Fix: prevent crash in PersistentContainer by safely unwrapping App Gr…

### DIFF
--- a/ClipKit/Database/DatabaseManager.swift
+++ b/ClipKit/Database/DatabaseManager.swift
@@ -39,13 +39,15 @@ private class PersistentContainer: RSTPersistentContainer
     {
         guard let appGroup = Bundle.main.appGroups.first else { return super.defaultDirectoryURL() }
         
-        let sharedDirectoryURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup)!
-        
-        let databaseDirectoryURL = sharedDirectoryURL.appendingPathComponent("Database")
-        try? FileManager.default.createDirectory(at: databaseDirectoryURL, withIntermediateDirectories: true, attributes: nil)
-        
-        print("Database URL:", databaseDirectoryURL)
-        return databaseDirectoryURL
+        if let sharedDirectoryURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup) {
+            let databaseDirectoryURL = sharedDirectoryURL.appendingPathComponent("Database")
+            try? FileManager.default.createDirectory(at: databaseDirectoryURL, withIntermediateDirectories: true, attributes: nil)
+            
+            print("Database URL:", databaseDirectoryURL)
+            return databaseDirectoryURL
+        } else {
+            return super.defaultDirectoryURL()
+        }
     }
 }
 


### PR DESCRIPTION
fixed a crash in PersistentContainer.defaultDirectoryURL() caused by a forced unwrap on the App Group. It now uses safe optional binding and falls back to super.defaultDirectoryURL() if unavailable.